### PR TITLE
Identity encoding isn't always acceptable

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ Accepts.prototype.encodings = function (encodings) {
   if (!Array.isArray(encodings)) encodings = slice.call(arguments);
   var n = this.negotiator;
   if (!encodings.length) return n.preferredEncodings();
-  return n.preferredEncodings(encodings)[0] || 'identity';
+  return n.preferredEncodings(encodings)[0] || false;
 }
 
 /**

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -21,7 +21,7 @@ describe('accepts.encodings()', function(){
       it('should return identity', function(){
         var accept = accepts();
         accept.encodings().should.eql(['identity']);
-        accept.encodings('gzip', 'deflate').should.equal('identity');
+        accept.encodings('gzip', 'deflate', 'identity').should.equal('identity');
       })
     })
   })


### PR DESCRIPTION
The identity encoding could be specifically refused if Accept-Encoding includes "identity;q=0". Negotiator already handles this, you should rely on it instead of always assuming the identity encoding is acceptable.
