### PR TITLE
Replace deep-equal with dequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "negotiator": "0.6.3"
   },
   "devDependencies": {
-    "deep-equal": "1.0.1",
+    "dequal": "2.0.3",
     "eslint": "7.32.0",
     "eslint-config-standard": "14.1.1",
     "eslint-plugin-import": "2.25.4",

--- a/test/charset.js
+++ b/test/charset.js
@@ -1,7 +1,7 @@
 
 var accepts = require('..')
 var assert = require('assert')
-var deepEqual = require('deep-equal')
+var deepEqual = require('dequal')
 
 describe('accepts.charsets()', function () {
   describe('with no arguments', function () {

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,7 +1,7 @@
 
 var accepts = require('..')
 var assert = require('assert')
-var deepEqual = require('deep-equal')
+var deepEqual = require('dequal')
 
 describe('accepts.encodings()', function () {
   describe('with no arguments', function () {

--- a/test/language.js
+++ b/test/language.js
@@ -1,7 +1,7 @@
 
 var accepts = require('..')
 var assert = require('assert')
-var deepEqual = require('deep-equal')
+var deepEqual = require('dequal')
 
 describe('accepts.languages()', function () {
   describe('with no arguments', function () {

--- a/test/type.js
+++ b/test/type.js
@@ -1,7 +1,7 @@
 
 var accepts = require('..')
 var assert = require('assert')
-var deepEqual = require('deep-equal')
+var deepEqual = require('dequal')
 
 describe('accepts.types()', function () {
   describe('with no arguments', function () {


### PR DESCRIPTION
This PR replaces deep-equal with dequal, an alternative package with 0 dependencies (as opposed to 49: https://npmgraph.js.org/?q=deep-equal).