### PR TITLE
enconding: Add preferred option

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ Accepts.prototype.types = function (types_) {
 Accepts.prototype.encoding =
 Accepts.prototype.encodings = function (encodings_, options_) {
   var encodings = encodings_
-  var preferred = arguments[arguments.length - 1]?.preferred || null
+  var preferred = arguments[arguments.length - 1] == null ? null : arguments[arguments.length - 1].preferred
 
   // support flattened arguments
   if (encodings && !Array.isArray(encodings)) {

--- a/index.js
+++ b/index.js
@@ -119,17 +119,22 @@ Accepts.prototype.types = function (types_) {
  *     ['gzip', 'deflate']
  *
  * @param {String|Array} encodings...
+ * @param {Object} options_
  * @return {String|Array}
  * @public
  */
 
 Accepts.prototype.encoding =
-Accepts.prototype.encodings = function (encodings_) {
+Accepts.prototype.encodings = function (encodings_, options_) {
   var encodings = encodings_
+  var preferred = arguments[arguments.length - 1]?.preferred || null
 
   // support flattened arguments
   if (encodings && !Array.isArray(encodings)) {
-    encodings = new Array(arguments.length)
+    var lenght = preferred ? arguments.length - 1 : arguments.length
+
+    encodings = new Array(lenght)
+
     for (var i = 0; i < encodings.length; i++) {
       encodings[i] = arguments[i]
     }
@@ -140,7 +145,7 @@ Accepts.prototype.encodings = function (encodings_) {
     return this.negotiator.encodings()
   }
 
-  return this.negotiator.encodings(encodings)[0] || false
+  return this.negotiator.encodings(encodings, { preferred: preferred })[0] || false
 }
 
 /**

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -56,6 +56,13 @@ describe('accepts.encodings()', function () {
       assert.strictEqual(accept.encodings('compress', 'gzip'), 'gzip')
       assert.strictEqual(accept.encodings('gzip', 'compress'), 'gzip')
     })
+
+    it('should accept a preferred encoding', function () {
+      var req = createRequest('gzip, br, compress')
+      var accept = accepts(req)
+      assert.strictEqual(accept.encodings('gzip', 'br', 'identity', { preferred: ['br'] }), 'br')
+      assert.strictEqual(accept.encodings('gzip', 'identity', 'br', { preferred: ['br'] }), 'br')
+    })
   })
 
   describe('with an array', function () {
@@ -63,6 +70,14 @@ describe('accepts.encodings()', function () {
       var req = createRequest('gzip, compress;q=0.2')
       var accept = accepts(req)
       assert.strictEqual(accept.encodings(['compress', 'gzip']), 'gzip')
+    })
+  })
+
+  describe('with preferred encoding', function () {
+    it('should return the preferred encoding', function () {
+      var req = createRequest('gzip, br')
+      var accept = accepts(req)
+      assert.strictEqual(accept.encodings(['br', 'gzip', 'identity'], { preferred: ['br'] }), 'br')
     })
   })
 })


### PR DESCRIPTION
Use of the preferred option in encoding

There must be a backport to version 1, as it is a feature needed for https://github.com/expressjs/compression/pull/194