### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
     "negotiation",
     "accept",
     "accepts"
-  ]
+  ],
+  "homepage": "https://github.com/jshttp/accepts",
+  "bugs": {
+    "url": "https://github.com/jshttp/accepts/issues"
+  }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.